### PR TITLE
model booking et Migration RenameBookingColumn giver_car_id et taker_…

### DIFF
--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -1,0 +1,5 @@
+class Booking < ApplicationRecord
+  belongs_to :giver_car, class_name: "Car"
+  belongs_to :taker_car, class_name: "Car"
+  belongs_to :parking
+end

--- a/app/models/car.rb
+++ b/app/models/car.rb
@@ -1,3 +1,5 @@
 class Car < ApplicationRecord
   belongs_to :user
+  has_many :givings, class_name: "Booking", foreign_key: :giver_car_id
+  has_many :takings, class_name: "Booking", foreign_key: :taker_car_id
 end

--- a/db/migrate/20230605145924_create_bookings.rb
+++ b/db/migrate/20230605145924_create_bookings.rb
@@ -1,0 +1,13 @@
+class CreateBookings < ActiveRecord::Migration[7.0]
+  def change
+    create_table :bookings do |t|
+      t.datetime :available_at
+      t.references :car, null: false, foreign_key: true
+      t.references :new_car, null: false, foreign_key: { to_table: "cars" }
+      t.references :parking, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end
+ 

--- a/db/migrate/20230605153509_rename_booking_columns.rb
+++ b/db/migrate/20230605153509_rename_booking_columns.rb
@@ -1,0 +1,6 @@
+class RenameBookingColumns < ActiveRecord::Migration[7.0]
+  def change
+    rename_column(:bookings, :car_id, :giver_car_id)
+    rename_column(:bookings, :new_car_id, :taker_car_id)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_05_145338) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_05_153509) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "bookings", force: :cascade do |t|
+    t.datetime "available_at"
+    t.bigint "giver_car_id", null: false
+    t.bigint "taker_car_id", null: false
+    t.bigint "parking_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["giver_car_id"], name: "index_bookings_on_giver_car_id"
+    t.index ["parking_id"], name: "index_bookings_on_parking_id"
+    t.index ["taker_car_id"], name: "index_bookings_on_taker_car_id"
+  end
 
   create_table "cars", force: :cascade do |t|
     t.string "model"
@@ -48,5 +60,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_05_145338) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "bookings", "cars", column: "giver_car_id"
+  add_foreign_key "bookings", "cars", column: "taker_car_id"
+  add_foreign_key "bookings", "parkings"
   add_foreign_key "cars", "users"
 end

--- a/test/models/booking_test.rb
+++ b/test/models/booking_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class BookingTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
J'ai créé le modele bvooking
J'ai vu avec le TA référent le soucis de gérer des "takers" de places libres et des "givers" de places libres.
Nous avons décidé de renommer les column du modele booking pour refléter clairement le "taker_car_id" et le "giver_car_id".
J'ai fait une migration pour renommer les column
Ceci est le dernier merge de cette 1ere journée
Tout le monde fera un pull demain matin mardi 6 juin